### PR TITLE
Forced dry run / Protected mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+update.lockfile
 target/

--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Explanations of all parameters can be seen by using the help flag, i.e. `cargo r
 without performing them. Instead they are logged at INFO level.
 - `test_exchange` (environment variable: `EUR2CCD_SERVICE_TEST_EXCHANGE`): If this parameter is given, the service will read exchanges from the given URL instead of at Bitfinex. (See /local_exchange for an example implementation)
 - `local_keys` (environment variable: `EUR2CCD_SERVICE_LOCAL_KEYS`): Comma separated names of files, which the service will attempt to read keys from, instead of from secrets on AWS. (Expects the files to contain arrays of keys)
+
+
+## Forced dry run
+If the halt thresholds are violated, the service will enter dry run mode. After Restarting the service, it will forcibly enter dry run mode again.
+
+To disable this forced dry run, remove the `update.lockfile` at:
+```
+/var/lib/concordium-eur2ccd-service/update.lockfile
+```

--- a/scripts/debian-package/build.sh
+++ b/scripts/debian-package/build.sh
@@ -62,6 +62,10 @@ LockPersonality=yes
 RestrictRealtime=yes
 MemoryDenyWriteExecute=yes
 
+# state directory is relative to /var/lib/, see systemd man pages Sandboxing section.
+StateDirectory=concordium-eur2ccd-service
+WorkingDirectory=%S/concordium-eur2ccd-service
+
 Environment=EUR2CCD_SERVICE_NODE=http://127.0.0.1:10000
 Environment=EUR2CCD_SERVICE_RPC_TOKEN=rpcadmin
 Environment=EUR2CCD_SERVICE_UPDATE_INTERVAL=1800

--- a/scripts/debian-package/build.sh
+++ b/scripts/debian-package/build.sh
@@ -63,7 +63,7 @@ RestrictRealtime=yes
 MemoryDenyWriteExecute=yes
 
 # state directory is relative to /var/lib/, see systemd man pages Sandboxing section.
-StateDirectory=concordium-eur2ccd-service
+StateDirectory=%S/concordium-eur2ccd-service
 WorkingDirectory=%S/concordium-eur2ccd-service
 
 Environment=EUR2CCD_SERVICE_NODE=http://127.0.0.1:10000

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ pub const MAX_RETRIES: u64 = 5; // When attempting to reach exchange
 pub const INITIAL_RETRY_INTERVAL: u64 = 10; // seconds, when attempting to reach exchange. (This gets doubled each
                                             // unsuccessful try)
 pub const BITFINEX_URL: &str = "https://api-pub.bitfinex.com/v2/calc/fx";
+pub const FORCED_DRY_RUN_FILE: &str = "update.lockfile";
 
 pub const CHECK_SUBMISSION_STATUS_INTERVAL: u64 = 5; // seconds
 pub const RETRY_SUBMISSION_INTERVAL: u64 = 10; // seconds

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,6 +253,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let mut signer = if app.dry_run || forced_dry_run {
+        stats.set_protected();
         None
     } else {
         let secret_keys = if app.local_keys.is_empty() {
@@ -310,6 +311,7 @@ async fn main() -> anyhow::Result<()> {
                 );
                 force_dry_run();
                 signer = None;
+                stats.set_protected();
                 continue;
             } else if diff > warning_increase_threshold {
                 log::warn!(
@@ -333,6 +335,7 @@ async fn main() -> anyhow::Result<()> {
                 );
                 force_dry_run();
                 signer = None;
+                stats.set_protected();
                 continue;
             } else if diff > warning_decrease_threshold {
                 log::warn!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn force_dry_run() {
     }
 }
 
-/// Checks if the file, which force_dry_run creates, has created.
+/// Checks if the file, which force_dry_run creates, exists.
 fn is_dry_run_forced() -> bool {
     std::path::Path::exists(std::path::Path::new(config::FORCED_DRY_RUN_FILE))
 }


### PR DESCRIPTION
## Purpose

Halt threshold violation causes the service to force dry run instead of stopping.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
