### PR TITLE
Create database tables at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-eur2ccd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-eur2ccd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/database.rs
+++ b/src/database.rs
@@ -5,10 +5,18 @@ const READ_RATE_STATEMENT: &str =
     "insert into read_values (value, timestamp) values (:value, :timestamp)";
 const UPDATE_RATE_STATEMENT: &str = "insert into updates (numerator, denominator, timestamp) \
                                      values (:numerator, :denominator, :timestamp)";
+const CREATE_TABLES: &str = "CREATE TABLE IF NOT EXISTS read_values (value DOUBLE NOT NULL, \
+                             timestamp DATETIME NOT NULL); CREATE TABLE IF NOT EXISTS updates \
+                             (numerator BIGINT UNSIGNED NOT NULL, denominator BIGINT UNSIGNED NOT \
+                             NULL, timestamp DATETIME NOT NULL)";
 
 pub fn establish_connection_pool(url: &str) -> mysql::Result<Pool> {
     Pool::new(Opts::from_url(url)?)
 }
+
+/// Creates the tables, we are inserting data into. (If they don't exist
+/// already)
+pub fn create_tables(conn: &mut PooledConn) -> mysql::Result<()> { conn.query_drop(CREATE_TABLES) }
 
 pub fn write_read_rate(conn: &mut PooledConn, value: f64) -> mysql::Result<()> {
     let statement = conn.prep(READ_RATE_STATEMENT)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,9 @@ async fn main() -> anyhow::Result<()> {
     let (mut main_database_conn, reader_database_conn) = {
         if let Some(url) = app.database_url {
             let pool = database::establish_connection_pool(&url)?;
-            (Some(pool.get_conn()?), Some(pool.get_conn()?))
+            let mut main_conn = pool.get_conn()?;
+            database::create_tables(&mut main_conn)?;
+            (Some(main_conn), Some(pool.get_conn()?))
         } else {
             log::warn!(
                 "No database url provided, service will not save to read and updated rates!"


### PR DESCRIPTION
## Purpose

Create the used database tables at startup. (If they don't exist)
Bumped version to 0.2.1.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
