### PR TITLE
Fix a block summary parsing error in the SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased changes
 
+# 0.4.1
+ - Bump the SDK to fix a JSON parsing error that would sometimes lead to block
+   summary parsing errors.
+
 # 0.4.0
 
  - Compatibility with node version 4.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-eur2ccd"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-eur2ccd"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Purpose

Fix a block summary parsing by updating the SDK. This only affects blocks which have a time parameter update so should be rare.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
