### PR TITLE
Fix parsing of key updates in block summaries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -742,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-eur2ccd"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-rust-sdk"
-version = "1.0.0"
+version = "1.0.3"
 dependencies = [
  "aggregate_sig",
  "anyhow",
@@ -788,6 +788,8 @@ dependencies = [
  "hex",
  "id",
  "num",
+ "num-bigint 0.4.3",
+ "num-traits",
  "prost",
  "rand 0.7.3",
  "random_oracle",
@@ -2616,6 +2618,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+ "rand_pcg",
 ]
 
 [[package]]
@@ -2684,6 +2687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-eur2ccd"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Purpose

The Rust SDK did not support the new V1 variants so it failed parsing some block summaries.

## Changes

The fix is in the SDK parsing.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.