### PR TITLE
parameterize rust build image

### DIFF
--- a/jenkinsfiles/Jenkinsfile
+++ b/jenkinsfiles/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         stage('Build') {
             steps {
                 sh '''\
-                    docker build -t ccd-service-builder --build-arg ubuntu_version=${base_image} -f scripts/debian-package/deb.Dockerfile .
+                    docker build -t ccd-service-builder --build-arg ubuntu_version=${base_image} --build-arg rust_image_tag=${rust_image_tag} -f scripts/debian-package/deb.Dockerfile .
 
                     set -euxo pipefail
 

--- a/scripts/debian-package/deb.Dockerfile
+++ b/scripts/debian-package/deb.Dockerfile
@@ -2,9 +2,10 @@
 # that will be added to the package. This should be the same as was used to
 # build the binaries.
 ARG ubuntu_version
+ARG rust_image_tag
 
 # Build the binary
-FROM rust:1.64 as builder
+FROM rust:$rust_image_tag as builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Purpose

Currently the rust build image is hardcoded, changed it to be parameterized from Jenkins, where the `rust_image_tag` is defaulted to 1.68

## Checklist

- [ ] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

