### PR TITLE
fix: add user agent header for coin gecko calls to resolve issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Updated the `concordium-rust-sdk` dependency and adjust project to be forward-compatible.
 
+# 0.8.1
+
+- Bug fix for providing a populated user agent header for coin gecko.
+
 # 0.8.0
 
 - Updated the Concordium Rust SDK.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-eur2ccd"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-eur2ccd"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.85"
 

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -65,13 +65,9 @@ trait RequestExchangeRate: fmt::Display {
 
 impl RequestExchangeRate for Source {
     fn get_request(&self, client: reqwest::Client) -> reqwest::RequestBuilder {
-
         // User agent header is required to contain a value for some exchanges. Here we will set the cargo package name and version.
         // eg: concordium-eur2ccd/x.y.z
-        let user_agent_value = format!("{}/{}",
-            env!("CARGO_PKG_NAME"),
-            env!("CARGO_PKG_VERSION"),
-        );
+        let user_agent_value = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"),);
 
         match self {
             Source::Bitfinex => client
@@ -191,7 +187,13 @@ async fn request_exchange_rate(source: &Source, client: reqwest::Client) -> Opti
         let status = resp.status();
         let headers = resp.headers().clone();
         let body = resp.text().await.unwrap_or_default();
-        log::warn!("{}: unsuccessful response. Status: {}, headers: {:?}, body: {}", source, status, headers, body);
+        log::warn!(
+            "{}: unsuccessful response. Status: {}, headers: {:?}, body: {}",
+            source,
+            status,
+            headers,
+            body
+        );
     };
     None
 }

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -65,7 +65,7 @@ trait RequestExchangeRate: fmt::Display {
 
 impl RequestExchangeRate for Source {
     fn get_request(&self, client: reqwest::Client) -> reqwest::RequestBuilder {
-        // User agent header is required to contain a value for some exchanges. 
+        // User agent header is required to contain a value for some exchanges.
         // Here we will set the cargo package name and version.
         // eg: concordium-eur2ccd/x.y.z
         let user_agent_value = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"),);

--- a/src/sources.rs
+++ b/src/sources.rs
@@ -65,7 +65,8 @@ trait RequestExchangeRate: fmt::Display {
 
 impl RequestExchangeRate for Source {
     fn get_request(&self, client: reqwest::Client) -> reqwest::RequestBuilder {
-        // User agent header is required to contain a value for some exchanges. Here we will set the cargo package name and version.
+        // User agent header is required to contain a value for some exchanges. 
+        // Here we will set the cargo package name and version.
         // eg: concordium-eur2ccd/x.y.z
         let user_agent_value = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"),);
 


### PR DESCRIPTION
## Purpose

Coin gecko currently rejects requests due to user agent not populated 

## Changes

- Add header for calls to coingecko
- Added additional logs to help with other failing requests in future, that helped resolve this issue
- Bump patch version of the service for release to resolve the issue in all environments
- Updated changelog

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

